### PR TITLE
docs(m2): define Workspace-owned pre-engagement communication

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -73,6 +73,27 @@ _Avoid_: MusicTrack, deliverable
 
 ## Engagement and deals
 
+**MatchmakerConversation**:
+A private, buyer-Workspace-owned exchange that develops a project brief before a ProjectRequest.
+Its human participants act through current WorkspaceMembership authority.
+_Avoid_: User conversation, cross-Workspace chat
+
+**ProjectBrief**:
+A buyer Workspace's structured description of desired work, separating searchable required
+constraints, searchable preferences, and project requirements that a seller must review. A
+confirmed brief informs a ProjectRequest but is not approved deal terms.
+_Avoid_: Prompt, ProjectRequest, TermsVersion
+
+**WorkspaceBlock**:
+A private boundary through which one Workspace prevents another Workspace from initiating new
+marketplace contact. It is distinct from a platform report or enforcement action.
+_Avoid_: User block, suspension, report
+
+**MarketplaceReport**:
+A participant's request for authorized human review of marketplace content or conduct. A report
+preserves review evidence but is not itself a block, finding, or enforcement action.
+_Avoid_: Complaint verdict, automatic suspension
+
 **ProjectRequest**:
 A buyer Workspace's invitation to a seller Workspace to discuss a project. Seller acceptance
 opens negotiation but does not approve terms or activate paid work.

--- a/docs/adr/0007-workspaces-own-pre-engagement-communication.md
+++ b/docs/adr/0007-workspaces-own-pre-engagement-communication.md
@@ -1,0 +1,20 @@
+---
+status: accepted
+---
+
+# Workspaces own pre-engagement communication
+
+MatchmakerConversations, ProjectBriefs, and ProjectRequests belong to the acting buyer Workspace,
+not to the UserAccount that initiated them. Humans participate through current
+WorkspaceMembership authority so organizational work survives member turnover without allowing
+content to cross Workspace boundaries.
+
+## Consequences
+
+- Current authorized members may continue Workspace-owned conversations and requests; revoked
+  members lose access while their prior actions remain attributed in audit evidence.
+- Human attribution is visible within the acting Workspace and to authorized reviewers, while the
+  other marketplace party receives only allow-listed Workspace identity and public marketplace
+  information.
+- Changing the UI's acting Workspace never transfers or continues a conversation, brief, or
+  request under the newly selected Workspace.


### PR DESCRIPTION
Adds ADR 0007 establishing that MatchmakerConversations, ProjectBriefs, and ProjectRequests belong to the acting buyer Workspace rather than the initiating UserAccount, and extends CONTEXT.md with the canonical terms and avoid-lists for MatchmakerConversation, ProjectBrief, WorkspaceBlock, and MarketplaceReport.